### PR TITLE
(#93) feat: move lucy_msgs to lucy_ros_packages and add config pipeline interfaces

### DIFF
--- a/lucy_msgs/CMakeLists.txt
+++ b/lucy_msgs/CMakeLists.txt
@@ -3,9 +3,13 @@ project(lucy_msgs)
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(action_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RawSensor.msg"
+  "action/ConfigurePipeline.action"
+  DEPENDENCIES action_msgs builtin_interfaces
 )
 
 ament_package()

--- a/lucy_msgs/CMakeLists.txt
+++ b/lucy_msgs/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.8)
+project(lucy_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/RawSensor.msg"
+)
+
+ament_package()

--- a/lucy_msgs/CMakeLists.txt
+++ b/lucy_msgs/CMakeLists.txt
@@ -9,6 +9,11 @@ find_package(builtin_interfaces REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RawSensor.msg"
   "action/ConfigurePipeline.action"
+  "srv/ListConfigs.srv"
+  "srv/GetConfig.srv"
+  "srv/SaveConfig.srv"
+  "srv/ActivateConfig.srv"
+  "srv/DeleteConfig.srv"
   DEPENDENCIES action_msgs builtin_interfaces
 )
 

--- a/lucy_msgs/action/ConfigurePipeline.action
+++ b/lucy_msgs/action/ConfigurePipeline.action
@@ -1,5 +1,5 @@
 # Goal: trigger the hardware configuration pipeline
-string robot_package          # e.g. "thais_urdf"
+string robot_package          # e.g. "inmoov_urdf"
 string mapping_file           # config name or path (empty = active config)
 string[] boards_to_flash      # board names to flash (empty = all boards)
 bool dry_run                  # validate + generate only, no build/flash

--- a/lucy_msgs/action/ConfigurePipeline.action
+++ b/lucy_msgs/action/ConfigurePipeline.action
@@ -1,0 +1,19 @@
+# Goal: trigger the hardware configuration pipeline
+string robot_package          # e.g. "thais_urdf"
+string mapping_file           # config name or path (empty = active config)
+string[] boards_to_flash      # board names to flash (empty = all boards)
+bool dry_run                  # validate + generate only, no build/flash
+bool build_only               # validate + generate + build, no flash
+---
+# Result
+bool success
+string message
+string config_name            # name of the config that was applied
+string[] boards_flashed       # board names that were successfully flashed
+string[] errors               # per-phase error messages (if any)
+---
+# Feedback
+string phase                  # "validate", "generate", "build", "flash"
+string board                  # current board being processed (empty if N/A)
+float32 progress              # 0.0 to 1.0 within the current phase
+string detail                 # human-readable status message

--- a/lucy_msgs/msg/RawSensor.msg
+++ b/lucy_msgs/msg/RawSensor.msg
@@ -1,0 +1,1 @@
+float32[] values

--- a/lucy_msgs/package.xml
+++ b/lucy_msgs/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <depend>action_msgs</depend>
+  <depend>builtin_interfaces</depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>

--- a/lucy_msgs/package.xml
+++ b/lucy_msgs/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>lucy_msgs</name>
+  <version>0.1.0</version>
+  <description>ROS2 interface definitions for Lucy robot: messages, actions, and services</description>
+  <maintainer email="contact@sentience-robotics.fr">Sentience Robotics Team</maintainer>
+  <license>GPL-3.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/lucy_msgs/srv/ActivateConfig.srv
+++ b/lucy_msgs/srv/ActivateConfig.srv
@@ -1,5 +1,5 @@
 # Request
-string robot_package          # e.g. "thais_urdf"
+string robot_package          # e.g. "inmoov_urdf"
 string config_name            # name of config to activate
 ---
 # Response

--- a/lucy_msgs/srv/ActivateConfig.srv
+++ b/lucy_msgs/srv/ActivateConfig.srv
@@ -1,0 +1,8 @@
+# Request
+string robot_package          # e.g. "thais_urdf"
+string config_name            # name of config to activate
+---
+# Response
+bool success
+string message
+string backup_name            # name of the backup created from the previous active config

--- a/lucy_msgs/srv/DeleteConfig.srv
+++ b/lucy_msgs/srv/DeleteConfig.srv
@@ -1,0 +1,7 @@
+# Request
+string robot_package          # e.g. "thais_urdf"
+string config_name            # name of config to delete
+---
+# Response
+bool success
+string message

--- a/lucy_msgs/srv/DeleteConfig.srv
+++ b/lucy_msgs/srv/DeleteConfig.srv
@@ -1,5 +1,5 @@
 # Request
-string robot_package          # e.g. "thais_urdf"
+string robot_package          # e.g. "inmoov_urdf"
 string config_name            # name of config to delete
 ---
 # Response

--- a/lucy_msgs/srv/GetConfig.srv
+++ b/lucy_msgs/srv/GetConfig.srv
@@ -1,0 +1,9 @@
+# Request
+string robot_package          # e.g. "thais_urdf"
+string config_name            # name of config to retrieve (empty = active)
+---
+# Response
+bool success
+string message
+string config_name            # resolved config name
+string config_yaml            # full YAML content as string

--- a/lucy_msgs/srv/GetConfig.srv
+++ b/lucy_msgs/srv/GetConfig.srv
@@ -1,5 +1,5 @@
 # Request
-string robot_package          # e.g. "thais_urdf"
+string robot_package          # e.g. "inmoov_urdf"
 string config_name            # name of config to retrieve (empty = active)
 ---
 # Response

--- a/lucy_msgs/srv/ListConfigs.srv
+++ b/lucy_msgs/srv/ListConfigs.srv
@@ -1,0 +1,8 @@
+# Request
+string robot_package          # e.g. "thais_urdf"
+---
+# Response
+bool success
+string message
+string active_config          # name of the currently active config
+string[] config_names         # all available config names

--- a/lucy_msgs/srv/ListConfigs.srv
+++ b/lucy_msgs/srv/ListConfigs.srv
@@ -1,5 +1,5 @@
 # Request
-string robot_package          # e.g. "thais_urdf"
+string robot_package          # e.g. "inmoov_urdf"
 ---
 # Response
 bool success

--- a/lucy_msgs/srv/SaveConfig.srv
+++ b/lucy_msgs/srv/SaveConfig.srv
@@ -1,0 +1,11 @@
+# Request
+string robot_package          # e.g. "thais_urdf"
+string config_name            # name to save as
+string config_yaml            # full YAML content as string
+bool activate                 # also activate this config after saving
+---
+# Response
+bool success
+string message
+string[] validation_errors    # blocking schema/consistency errors
+string[] urdf_warnings        # non-blocking URDF cross-check warnings

--- a/lucy_msgs/srv/SaveConfig.srv
+++ b/lucy_msgs/srv/SaveConfig.srv
@@ -1,5 +1,5 @@
 # Request
-string robot_package          # e.g. "thais_urdf"
+string robot_package          # e.g. "inmoov_urdf"
 string config_name            # name to save as
 string config_yaml            # full YAML content as string
 bool activate                 # also activate this config after saving


### PR DESCRIPTION
## Summary

- Move `lucy_msgs` interface package from `micro_ros_raspberrypi_pico_sdk` into `lucy_ros_packages` where it belongs alongside the ROS2 nodes that consume it
- Add `ConfigurePipeline` action definition for the hardware config pipeline (goal: robot_package, boards, dry_run; result: success, boards_flashed, errors; feedback: phase, progress, detail)
- Add 5 config management service definitions: `ListConfigs`, `GetConfig`, `SaveConfig`, `ActivateConfig`, `DeleteConfig`

Existing `msg/RawSensor.msg` is preserved unchanged. The pico firmware is unaffected (it uses precompiled headers from `libmicroros`). The workspace symlink `lucy_ws/src/lucy_msgs` should be removed after merge so colcon finds the package inside `lucy_ros_packages/` directly.

## Test plan

- [x] `colcon build --packages-select lucy_msgs` succeeds
- [x] `ros2 interface list | grep lucy_msgs` shows all 7 interfaces (1 msg, 1 action, 5 srv)
- [ ] Downstream packages that depend on `lucy_msgs` still build after removing the symlink

Refs: https://github.com/Sentience-Robotics/lucy_ros2/issues/93